### PR TITLE
Updated UniPlaneMeshGenerator.Editor.asmdef to include only Editor platform

### DIFF
--- a/Assets/UniPlaneMeshGenerator/Editor/UniPlaneMeshGenerator.Editor.asmdef
+++ b/Assets/UniPlaneMeshGenerator/Editor/UniPlaneMeshGenerator.Editor.asmdef
@@ -3,7 +3,9 @@
     "references": [
         "GUID:d878b916b828f483f99a692535d38f9e"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
Otherwise, the build process always fails if this package is added to the project due to no access to the UnityEditor namespace